### PR TITLE
Update EnemyRobotPrefab.prefab

### DIFF
--- a/Assets/Game/Prefabs/Stage/Robots/Templates/EnemyRobotPrefab.prefab
+++ b/Assets/Game/Prefabs/Stage/Robots/Templates/EnemyRobotPrefab.prefab
@@ -1,445 +1,110 @@
-%YAML 1.1
+#!/usr/bin/env python3
+"""
+Demonstration: parse a multi-document Unity YAML snippet and potentially modify fields.
+Requires PyYAML or a similar library. 
+"""
+
+import yaml
+
+yaml_input = r"""%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &4048360104100510366
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6411893797768784338}
-  - component: {fileID: 3799528289645521946}
-  m_Layer: 0
-  m_Name: Movement Direction Timer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
+  ...
 --- !u!4 &6411893797768784338
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4048360104100510366}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5713532323854920377}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  ...
 --- !u!114 &3799528289645521946
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4048360104100510366}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 03fa35555f60b8344aac1210d6ce0ae7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  duration: 0.25
-  countFromTheStart: 0
-  onReset:
-    m_PersistentCalls:
-      m_Calls: []
-  onEnd:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: -2978630073550354148}
-        m_TargetAssemblyTypeName: EnemyRobotMovement, Assembly-CSharp
-        m_MethodName: RandomiseDirection
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: -2978630073550354148}
-        m_TargetAssemblyTypeName: EnemyRobotMovement, Assembly-CSharp
-        m_MethodName: SetCollisionDetectionState
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  onInterrupt:
-    m_PersistentCalls:
-      m_Calls: []
+  ...
+  movementSpeed: 1
+  ...
 --- !u!1 &5069509302619420089
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1289978992512302485}
-  - component: {fileID: 3656771208232311577}
-  - component: {fileID: 4447308969246344198}
-  m_Layer: 15
-  m_Name: Collision Detector
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
+  ...
 --- !u!4 &1289978992512302485
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5069509302619420089}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5713532323854920377}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  ...
 --- !u!61 &3656771208232311577
 BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5069509302619420089}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.33}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.72, y: 0.1}
-  m_EdgeRadius: 0
+  ...
 --- !u!114 &4447308969246344198
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5069509302619420089}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67539fa7da496d24ea92e5aa98693030, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  detectionLayers:
-    serializedVersion: 2
-    m_Bits: 98048
+  ...
 --- !u!1 &5074757979470416933
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4117364974871369739}
-  - component: {fileID: 7952846313805569692}
-  m_Layer: 0
-  m_Name: Shoot Timer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
+  ...
 --- !u!4 &4117364974871369739
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5074757979470416933}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5713532323854920377}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  ...
 --- !u!114 &7952846313805569692
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5074757979470416933}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 03fa35555f60b8344aac1210d6ce0ae7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  duration: 1
-  countFromTheStart: 1
-  onReset:
-    m_PersistentCalls:
-      m_Calls: []
-  onEnd:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1097374135248273911}
-        m_TargetAssemblyTypeName: RobotShoot, Assembly-CSharp
-        m_MethodName: FireBullet
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 7952846313805569692}
-        m_TargetAssemblyTypeName: Timer, Assembly-CSharp
-        m_MethodName: ResetTimer
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  onInterrupt:
-    m_PersistentCalls:
-      m_Calls: []
+  ...
 --- !u!1001 &7305028705194506425
 PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_Name
-      value: EnemyRobotPrefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_Layer
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      propertyPath: m_TagString
-      value: Enemy
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 4366984621820829096, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-    - {fileID: 5886565102491951326, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4117364974871369739}
-    - targetCorrespondingSourceObject: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6411893797768784338}
-    - targetCorrespondingSourceObject: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1289978992512302485}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1097374135248273911}
-    - targetCorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: -2978630073550354148}
-    - targetCorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: -7222749067493573934}
-    - targetCorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: -165028709078084384}
-    - targetCorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: -7789898313100651961}
-    - targetCorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: -7993017942770709550}
-  m_SourcePrefab: {fileID: 100100000, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
+  ...
 --- !u!4 &5713532323854920377 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3038284362999386624, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-  m_PrefabInstance: {fileID: 7305028705194506425}
-  m_PrefabAsset: {fileID: 0}
+  ...
 --- !u!1 &5816500477355214006 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 3880115763377585167, guid: 45af5603af150104993ac8c5bdc54084, type: 3}
-  m_PrefabInstance: {fileID: 7305028705194506425}
-  m_PrefabAsset: {fileID: 0}
+  ...
 --- !u!114 &1097374135248273911
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5816500477355214006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 51eb5726b32903146a9c7b7f4c7c3535, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
   bullet: {fileID: 1372171276495067033, guid: 8c4e0f4bbc5b492469be53cc62a61ca1, type: 3}
-  offsetFromObject: 0.1
+  ...
 --- !u!114 &-2978630073550354148
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5816500477355214006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9818a7bf096834c458e9dbaee7a98ea6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
   movementSpeed: 1
   timer: {fileID: 3799528289645521946}
-  collisionDetector: {fileID: 4447308969246344198}
+  ...
 --- !u!114 &-7222749067493573934
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5816500477355214006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ec868d51399bf1844ada2536eb6b7e3a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  obstacleDetectionLayers:
-    serializedVersion: 2
-    m_Bits: 19968
-  obstacleDetectionDistance: 0.65
+  ...
 --- !u!114 &-165028709078084384
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5816500477355214006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d64e1510ae35de74dbcac45a5c1b8845, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  shootTimer: {fileID: 7952846313805569692}
+  ...
 --- !u!114 &-7789898313100651961
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5816500477355214006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 988d7bd1636773c4996ccadbd41b7e26, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  initialHealth: 1
-  data: {fileID: 0}
+  ...
 --- !u!114 &-7993017942770709550
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5816500477355214006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 37a73e9d34708df4ba5eed50d4ab0e5c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  ...
+"""
+
+def main():
+    # Parse all documents
+    documents = list(yaml.safe_load_all(yaml_input))
+    
+    print(f"Number of documents found: {len(documents)}\n")
+
+    # Each doc is typically a dict like { 'GameObject': { ... } } or { 'Transform': { ... } }
+    for index, doc in enumerate(documents):
+        if not isinstance(doc, dict):
+            # Possibly None or something else
+            print(f"Doc #{index} is not a dict, skipping.")
+            continue
+
+        # There's usually exactly one top-level key, e.g. 'GameObject', 'MonoBehaviour', ...
+        top_keys = list(doc.keys())
+        if top_keys:
+            main_key = top_keys[0]
+            print(f"Doc #{index}: top-level key is '{main_key}'")
+            
+            if main_key == "MonoBehaviour":
+                # Let's see if there's a 'movementSpeed' field 
+                mono_data = doc["MonoBehaviour"]
+                if "movementSpeed" in mono_data:
+                    print(f"  Found 'movementSpeed' = {mono_data['movementSpeed']}. Let's update it to 2.")
+                    mono_data["movementSpeed"] = 2  # Modify it in place
+
+    # We'll re-dump them. But note that the custom tags (`!u!114 &3799528289645521946`) won't be retained automatically.
+    # We'll just demonstrate that we've updated the data structure. 
+    updated_yaml = yaml.dump_all(documents, sort_keys=False)
+    
+    print("\n[Updated YAML (losing Unity’s !u!/fileID tags)]:\n")
+    print(updated_yaml)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. Verify Understanding You’ve provided a Unity scene/prefab YAML snippet containing multiple !u! sections (each one describing different Unity objects like GameObject, Transform, MonoBehaviour, BoxCollider2D, etc.). In Unity’s serialized YAML:

--- !u!<classID> &<fileID> indicates a new object of a certain type (e.g., 1 = GameObject, 4 = Transform, 114 = MonoBehaviour, etc.). Each object has properties like m_GameObject, m_Enabled, m_Script, etc. You might want to parse this YAML to:

Analyze or extract references (e.g., a script’s GUIDs). Modify certain fields (e.g., change a m_Layer or adjust a movementSpeed). Re-generate or create a build pipeline step that does some validation or manipulation automatically. While you can treat it as standard YAML, it has some unusual lines (%TAG !u! tag:unity3d.com,2011:), multi-document structure, special references ({fileID: …}), and custom !u! tags for each object. Still, PyYAML in Python can handle multi-document YAML just fine if you’re prepared to read each document in the sequence.

2. Outline Approach Read the snippet (or a .unity/.prefab/.asset file) as a plain text string. Parse with PyYAML using yaml.safe_load_all(...) because there are multiple --- documents. Process each doc: you’ll get a dictionary containing fields like GameObject: { ... }, MonoBehaviour: { ... }, etc. Locate the key(s) you want to change. For instance, if you want to set movementSpeed to 2 where the MonoBehaviour references a certain script, you look for docs that have a MonoBehaviour key and check m_Script.guid. Re-serialize. Because Unity’s YAML has these custom tags (!u!ClassID &fileID), we’ll have to preserve them or re-construct them if you need to round-trip changes back into a valid Unity file. Note: PyYAML typically discards custom tags by default, or it transforms them into Python’s yaml.nodes.Tag. You can handle them manually. For simpler tasks, you may just need to parse out the data. If you want to fully round-trip (no changes in the file except your modifications), you might need a more advanced solution that preserves the YAML structure (like ruamel.yaml with round-trip mode).

3. Example Python Script (Reading/Inspecting Documents) Below is a demonstration that reads your snippet, lists each document’s top-level key (like GameObject, Transform, etc.), and if we find a MonoBehaviour referencing a certain script GUID, we update a field (e.g., movementSpeed).

python
Copy code
#!/usr/bin/env python3
"""
Demonstration: parse a multi-document Unity YAML snippet and potentially modify fields. Requires PyYAML or a similar library. 
"""

import yaml

yaml_input = r"""%YAML 1.1
%TAG !u! tag:unity3d.com,2011:
--- !u!1 &4048360104100510366
GameObject:
  m_ObjectHideFlags: 0
  ...
--- !u!4 &6411893797768784338
Transform:
  ...
--- !u!114 &3799528289645521946
MonoBehaviour:
  ...
  movementSpeed: 1
  ...
--- !u!1 &5069509302619420089
GameObject:
  ...
--- !u!4 &1289978992512302485
Transform:
  ...
--- !u!61 &3656771208232311577
BoxCollider2D:
  ...
--- !u!114 &4447308969246344198
MonoBehaviour:
  ...
--- !u!1 &5074757979470416933
GameObject:
  ...
--- !u!4 &4117364974871369739
Transform:
  ...
--- !u!114 &7952846313805569692
MonoBehaviour:
  ...
--- !u!1001 &7305028705194506425
PrefabInstance:
  ...
--- !u!4 &5713532323854920377 stripped
Transform:
  ...
--- !u!1 &5816500477355214006 stripped
GameObject:
  ...
--- !u!114 &1097374135248273911
MonoBehaviour:
  bullet: {fileID: 1372171276495067033, guid: 8c4e0f4bbc5b492469be53cc62a61ca1, type: 3}
  ...
--- !u!114 &-2978630073550354148
MonoBehaviour:
  movementSpeed: 1
  timer: {fileID: 3799528289645521946}
  ...
--- !u!114 &-7222749067493573934
MonoBehaviour:
  ...
--- !u!114 &-165028709078084384
MonoBehaviour:
  ...
--- !u!114 &-7789898313100651961
MonoBehaviour:
  ...
--- !u!114 &-7993017942770709550
MonoBehaviour:
  ...
"""

def main():
    # Parse all documents
    documents = list(yaml.safe_load_all(yaml_input))
    
    print(f"Number of documents found: {len(documents)}\n")

    # Each doc is typically a dict like { 'GameObject': { ... } } or { 'Transform': { ... } }
    for index, doc in enumerate(documents):
        if not isinstance(doc, dict):
            # Possibly None or something else
            print(f"Doc #{index} is not a dict, skipping.")
            continue

        # There's usually exactly one top-level key, e.g. 'GameObject', 'MonoBehaviour', ...
        top_keys = list(doc.keys())
        if top_keys:
            main_key = top_keys[0]
            print(f"Doc #{index}: top-level key is '{main_key}'")
            
            if main_key == "MonoBehaviour":
                # Let's see if there's a 'movementSpeed' field 
                mono_data = doc["MonoBehaviour"]
                if "movementSpeed" in mono_data:
                    print(f"  Found 'movementSpeed' = {mono_data['movementSpeed']}. Let's update it to 2.")
                    mono_data["movementSpeed"] = 2  # Modify it in place

    # We'll re-dump them. But note that the custom tags (`!u!114 &3799528289645521946`) won't be retained automatically.
    # We'll just demonstrate that we've updated the data structure. 
    updated_yaml = yaml.dump_all(documents, sort_keys=False)
    
    print("\n[Updated YAML (losing Unity’s !u!/fileID tags)]:\n")
    print(updated_yaml)

if __name__ == "__main__":
    main()
Explanation
Load: We call safe_load_all(...) to parse the entire multi-document string. Inspect: For each doc, we get its single top-level key (like MonoBehaviour). If we see movementSpeed, we set it to 2.
Dump: We produce a new YAML sequence of docs. But we lose the special !u!4 &6411893797768784338 lines, since PyYAML doesn’t preserve them. If you need to preserve them for Unity to accept the file, see below.
4. Preserving the !u! Tags & &fileID PyYAML by default discards the tag. For a more robust approach, you could use ruamel.yaml’s round-trip mode or write a custom parser that preserves the top lines. Typically, these lines are stored as the “document tag” in YAML. If you only need to read or analyze but not re-save the exact file, you can ignore them. If you want a partial “reinject” approach, you might store the lines preceding each doc, do your modifications, then reinsert them manually.

5. Edge Cases Stripped objects: Some objects are marked stripped, meaning they have fewer fields. No top-level dictionary: Some docs might be empty or have unexpected format. Large Scenes: For big scenes, you can still parse them, but it might be slow or memory-heavy.
6. Potential Enhancements or Alternatives Use ruamel.yaml: This library can do a “round trip parse” that keeps comments, ordering, and tags, so you can re-save the file with minimal changes. Regex: For simpler tasks (like searching for movementSpeed and changing its numeric value in place), a well-crafted text-based approach might suffice. But it can break if the code changes format. C# Reflection: If you’re manipulating data inside the Unity Editor, you can do it with an Editor script in C#, directly reading or editing component fields. That’s often simpler from Unity’s perspective. Conclusion
This snippet shows how you can load and manipulate a multi-document Unity YAML file in Python. The primary challenge is that Unity’s special tags (!u!114 &3799528289645521946) and references won’t be preserved by default unless you do a more advanced approach like ruamel.yaml or manual string manipulation. For read-only analysis or minor transformations that don’t require re-saving the file exactly as is, a simple approach with PyYAML can suffice.